### PR TITLE
Replace "Optional Parameters"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,44 @@ To add it to your to your existing workflow, append this to your current `.yml` 
 
 3. If you choose not to add the header it will be added automatically as your last section in readme.
 
+### Optional parameters
+
+You can add these optional parameters in your action script to modify the appearance of the resulting list.
+
+```yml
+- name: Contribute List
+  with:
+    header: Developers
+    columnsPerRow: 6
+```
+
+1. To change the header of the section:
+
+```yml
+header: Contributors
+```
+
+The default value is `Contributors`.
+Feature Credit: [Hyeonseok Samuel Seo](https://github.com/samslow)
+
+2. To change the image size inside the box:
+
+```yml
+imageSize: 100
+```
+
+The default value is `100px x 100px`.
+
+3. To change the number of columns in a row:
+
+```yml
+columnsPerRow: 6
+```
+
+The default value is `6`.
+
 ## Contributors :sparkles:
+
 <table>
 <tr>
                 <td align="center">


### PR DESCRIPTION
I am not sure why, but the GitHub Action seems to have [removed this section](https://github.com/akhilmhdh/contributors-readme-action/commit/6c3481133c92ec83dc2a8551124510d8191744ad).