### PR TITLE
docs: fix name of option `use_username`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can add these optional parameters in your action script to modify the appear
 | image_size         | 100(px)                                  | Size of square images in the stack                                                                          | false    |
 | is_protected       | false                                    | If the branch to be updated is protected change this to true to change from directly commiting to PR update | false    |
 | readme_path        | README.md                                | Path of the readme file you want to update                                                                  | false    |
-| user_username      | false                                    | To use username instead of full name                                                                        | false    |
+| use_username      | false                                    | To use username instead of full name                                                                        | false    |
 | columns_per_row    | 6                                        | Number of columns in a row                                                                                  | false    |
 | collaborators      | direct                                   | Type of collaborators options: all/direct/outside                                                           | false    |
 | commit_message     | contrib-readme-action has updated readme | Commit message of the github action                                                                         | false    |


### PR DESCRIPTION
Currently your README mentions the option `user_username` while the correct name is `use_username`.