### PR TITLE
Fix output `pr_id`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ async function run() {
                     head: branchNameForPR,
                     title: prTitle
                 });
-                setOutput('pr_id', prDetails.data.id);
+                setOutput('pr_id', prDetails.data.number);
             } else {
                 await octokit.rest.repos.createOrUpdateFileContents({
                     owner,


### PR DESCRIPTION
Hey @akhilmhdh ! I was implementing your latest changes (thanks a lot for your reactivity!) and I was getting weird results when reusing your output `pr_id`.

It turns out, you were using the wrong key: `id` instead of `number`.

I know it is confusing, I would have done the same mistake, but that's GitHub's terminology ¯\_(ツ)_/¯ .

If you accept this fix, would you be okay to make a release right after please?