### PR TITLE
feat: use conventional commits format

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ You can add these optional parameters in your action script to modify the appear
 | use_username                  | false                                    | To use username instead of full name                            | false    |
 | columns_per_row               | 6                                        | Number of columns in a row                                      | false    |
 | collaborators                 | direct                                   | Type of collaborators options: all/direct/outside               | false    |
-| commit_message                | contrib-readme-action has updated readme | Commit message of the github action                             | false    |
+| commit_message                | docs(contributor): contrib-readme-action has updated readme | Commit message of the github action                             | false    |
 | committer_username            | ""                                       | Username on commit                                              | false    |
 | committer_email               | ""                                       | Email id of committer                                           | false    |
-| pr_title_on_protected         | contributors readme action update        | Title of the PR that will be created if the branch is protected | false    |
+| pr_title_on_protected         | docs(contributor): contributors readme action update        | Title of the PR that will be created if the branch is protected | false    |
 | auto_detect_branch_protection | true                                     | To override auto protected branch detection                     | false    |
 
 > committer_username and committer_email both must be provided to use as a replacement to GH action committer

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
         default: "direct"
     commit_message:
         description: "Commit message of the github action"
-        default: "contrib-readme-action has updated readme"
+        default: "docs: contrib-readme-action has updated readme"
         required: false
     committer_username:
         description: "Username on commit"
@@ -37,7 +37,7 @@ inputs:
         required: false
     pr_title_on_protected:
         description: "Title of the PR that will be created if the branch is protected"
-        default: "contributors readme action update"
+        default: "docs: contributors readme action update"
         required: false
 outputs:
     pr_id: # id of pr

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
         default: "direct"
     commit_message:
         description: "Commit message of the github action"
-        default: "docs: contrib-readme-action has updated readme"
+        default: "docs(contributor): contrib-readme-action has updated readme"
         required: false
     committer_username:
         description: "Username on commit"
@@ -37,7 +37,7 @@ inputs:
         required: false
     pr_title_on_protected:
         description: "Title of the PR that will be created if the branch is protected"
-        default: "docs: contributors readme action update"
+        default: "docs(contributor): contributors readme action update"
         required: false
 outputs:
     pr_id: # id of pr


### PR DESCRIPTION
Hi @akhilmhdh . Thanks for creating nice package. 

This PR change commit message and PR title as [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format to clarify the purpose of the commit.

Conventional Commits message format allows you to automate releases and changelog updates with actions that support the conventional commits format, such as https://github.com/google-github-actions/release-please-action.

Automated release example: https://github.com/google-github-actions/release-please-action/releases/tag/v3.2.9

If you have any plans not to use conventional commits, please close this PR.