### PR TITLE
Update node12 -> node18

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ outputs:
     pr_id: # id of pr
         description: "Id of the generated PR when the branch is in protected mode"
 runs:
-    using: "node12"
+    using: "node18"
     main: "dist/index.js"
 branding:
     icon: "archive"


### PR DESCRIPTION
This should close #58

[Nodejs LTS is currently `18.12.1`](https://nodejs.org/en/download/) and `node18` will get you the latest as per [their dockerhub](https://hub.docker.com/_/node).

Please let me know if you'd like to do a different version. I only dabble in js, so open to any better suggestions.

Thank you for your time :)